### PR TITLE
feat: add expiration parsing for 2nd-level JP domains

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -158,11 +158,7 @@ func TestParse(t *testing.T) {
 		}
 
 		if !assert.IsContains([]string{"", "ai", "at", "aq", "au", "br", "ch", "de", "eu", "gg", "gov", "ee",
-			"hm", "int", "name", "nl", "nz", "tk", "kz", "hu"}, extension) &&
-			!strings.Contains(domain, "ac.jp") &&
-			!strings.Contains(domain, "co.jp") &&
-			!strings.Contains(domain, "go.jp") &&
-			!strings.Contains(domain, "ne.jp") {
+			"hm", "int", "name", "nl", "nz", "tk", "kz", "hu"}, extension) {
 			assert.NotZero(t, whoisInfo.Domain.ExpirationDate)
 			assert.NotNil(t, whoisInfo.Domain.ExpirationDateInTime)
 		}

--- a/prepare.go
+++ b/prepare.go
@@ -752,6 +752,13 @@ func prepareSecondLevelJP(original string, token string, value string) string {
 	if strings.ToLower(token) == "organization" || strings.ToLower(token) == "network service name" {
 		return fmt.Sprintf("Registrant Organization: %s", strings.TrimSpace(value))
 	}
+	if strings.ToLower(token) == "state" {
+		re := regexp.MustCompile(`Connected \(([^)]+)\)`)
+		match := re.FindStringSubmatch(value)
+		if len(match) > 1 {
+			return fmt.Sprintf("State: %s\nExpires on: %s", value, match[1])
+		}
+	}
 	return original
 }
 

--- a/testdata/noterror/jp_goo.ne.jp.json
+++ b/testdata/noterror/jp_goo.ne.jp.json
@@ -15,7 +15,9 @@
         ],
         "created_date": "2004/06/15",
         "created_date_in_time": "2004-06-15T00:00:00Z",
-        "updated_date": "2023/07/31 12:30:39 (JST)"
+        "updated_date": "2023/07/31 12:30:39 (JST)",
+        "expiration_date": "2024/06/30",
+        "expiration_date_in_time": "2024-06-30T00:00:00Z"
     },
     "registrant": {
         "organization": "GOO"

--- a/testdata/noterror/jp_goo.ne.jp.pre
+++ b/testdata/noterror/jp_goo.ne.jp.pre
@@ -20,7 +20,8 @@ Name Server: ns2.goo.ne.jp
 Name Server: ns.intervia.ad.jp
 Name Server: ns.via.or.jp
 Signing Key:
-State: Connected (2024/06/30)
+State:  Connected (2024/06/30)
+Expires on: 2024/06/30
 Registered Date: 2004/06/15
 Connected Date: 2004/06/15
 Last Update: 2023/07/31 12:30:39 (JST)

--- a/testdata/noterror/jp_google.co.jp.json
+++ b/testdata/noterror/jp_google.co.jp.json
@@ -15,7 +15,9 @@
         ],
         "created_date": "2001/03/22",
         "created_date_in_time": "2001-03-22T00:00:00Z",
-        "updated_date": "2023/04/01 01:05:57 (JST)"
+        "updated_date": "2023/04/01 01:05:57 (JST)",
+        "expiration_date": "2024/03/31",
+        "expiration_date_in_time": "2024-03-31T00:00:00Z"
     },
     "registrant": {
         "organization": "Google Japan G.K."

--- a/testdata/noterror/jp_google.co.jp.pre
+++ b/testdata/noterror/jp_google.co.jp.pre
@@ -20,7 +20,8 @@ Name Server: ns2.google.com
 Name Server: ns3.google.com
 Name Server: ns4.google.com
 Signing Key:
-State: Connected (2024/03/31)
+State:  Connected (2024/03/31)
+Expires on: 2024/03/31
 Lock Status: AgentChangeLocked
 Registered Date: 2001/03/22
 Connected Date: 2001/03/22

--- a/testdata/noterror/jp_mod.go.jp.json
+++ b/testdata/noterror/jp_mod.go.jp.json
@@ -22,7 +22,9 @@
         ],
         "created_date": "2006/12/19",
         "created_date_in_time": "2006-12-19T00:00:00Z",
-        "updated_date": "2024/01/01 01:04:32 (JST)"
+        "updated_date": "2024/01/01 01:04:32 (JST)",
+        "expiration_date": "2024/12/31",
+        "expiration_date_in_time": "2024-12-31T00:00:00Z"
     },
     "registrant": {
         "organization": "Ministry of Defense"

--- a/testdata/noterror/jp_mod.go.jp.pre
+++ b/testdata/noterror/jp_mod.go.jp.pre
@@ -27,7 +27,8 @@ Name Server: auth3.ns.gin.ntt.net
 Name Server: auth4.ns.gin.ntt.net
 Name Server: auth5.ns.gin.ntt.net
 Signing Key:
-State: Connected (2024/12/31)
+State:  Connected (2024/12/31)
+Expires on: 2024/12/31
 Registered Date: 2006/12/19
 Connected Date: 2006/12/25
 Last Update: 2024/01/01 01:04:32 (JST)

--- a/testdata/noterror/jp_titech.ac.jp.json
+++ b/testdata/noterror/jp_titech.ac.jp.json
@@ -12,7 +12,9 @@
             "ns1.noc.titech.ac.jp",
             "ns2.noc.titech.ac.jp"
         ],
-        "updated_date": "2023/04/01 01:04:55 (JST)"
+        "updated_date": "2023/04/01 01:04:55 (JST)",
+        "expiration_date": "2024/03/31",
+        "expiration_date_in_time": "2024-03-31T00:00:00Z"
     },
     "registrant": {
         "organization": "Tokyo Institute of Technology"

--- a/testdata/noterror/jp_titech.ac.jp.pre
+++ b/testdata/noterror/jp_titech.ac.jp.pre
@@ -21,7 +21,8 @@ Name Server: ns.fujisawa.wide.ad.jp
 Name Server: ns1.noc.titech.ac.jp
 Name Server: ns2.noc.titech.ac.jp
 Signing Key:
-State: Connected (2024/03/31)
+State:  Connected (2024/03/31)
+Expires on: 2024/03/31
 Registered Date:
 Connected Date:
 Last Update: 2023/04/01 01:04:55 (JST)


### PR DESCRIPTION
- Parse expiration from "State: Connected (YYYY/MM/DD)" in 2nd-level JP domains
- Enable expiration assertions in 2nd-level JP domains tests